### PR TITLE
cmd: Introduce sc_cmd_register() and use it internally

### DIFF
--- a/include/sc_cmd.h
+++ b/include/sc_cmd.h
@@ -35,5 +35,7 @@ void sc_cmd_init(void);
 void sc_cmd_deinit(void);
 void sc_cmd_push_byte(uint8_t byte);
 uint16_t sc_cmd_blob_get(uint8_t **blob);
+typedef void (*sc_cmd_cb)(uint8_t*, uint8_t);
+void sc_cmd_register(uint8_t cmd, sc_cmd_cb cb);
 
 #endif


### PR DESCRIPTION
Projects can now register their own commands for the UART interface
