### PR TITLE
extint: Add simple debounced event handling

### DIFF
--- a/include/sc_extint.h
+++ b/include/sc_extint.h
@@ -44,6 +44,10 @@ typedef enum {
 void sc_extint_set_event(ioportid_t port,
                          uint8_t pin,
                          SC_EXTINT_EDGE mode);
+void sc_extint_set_debounced_event(ioportid_t port,
+                                 uint8_t pin,
+                                 SC_EXTINT_EDGE mode,
+                                 systime_t delay);
 void sc_extint_set_isr_cb(ioportid_t port,
                           uint8_t pin,
                           SC_EXTINT_EDGE mode,


### PR DESCRIPTION
Debounced events are only delivered after the specified timeout, ignoring
interrupts happening during that timeout. If the edge mode is rising or
falling, the event is delivered only if the pin settles into the desired
state (high or low). For both mode the event is always delivered after the
timeout regardless of what state the pin is in.

A practical example of usage is physical switches, which tend to have shaky
contact while operating from one position to another
