### PR TITLE
drivers: Add delay to lsm9ds0 init to avoid (possible) i2c problems on c...

### DIFF
--- a/drivers/sc_lsm9ds0.c
+++ b/drivers/sc_lsm9ds0.c
@@ -168,6 +168,10 @@ void sc_lsm9ds0_init(void)
 
   // Setup and start acc+magn
 
+  // We need to give a bit of time to the chip until we can ask it to shut down
+  // i2c not ready initially?
+  chThdSleepMilliseconds(20);
+
   // Shutdown the chip so that we get new data ready
   // interrupts even if the chip was already running
   sc_lsm9ds0_shutdown();


### PR DESCRIPTION
...old start
